### PR TITLE
Fix JSON parsing for Claude Code 2.0.55+ structured output

### DIFF
--- a/scripts/claude-judge-continuation.sh
+++ b/scripts/claude-judge-continuation.sh
@@ -106,8 +106,8 @@ if [ $? -ne 0 ]; then
     exit 0
 fi
 
-# Extract the structured output from the claude response (stream JSON format)
-EVALUATION_RESULT=$(echo "$CLAUDE_RESPONSE" | jq '.[] | select(.type == "result") | .structured_output // empty' 2>/dev/null)
+# Extract the structured output from the claude response (JSON format)
+EVALUATION_RESULT=$(echo "$CLAUDE_RESPONSE" | jq '.structured_output // empty' 2>/dev/null)
 
 # If no structured output, fall back to allowing stop
 if [ -z "$EVALUATION_RESULT" ] || [ "$EVALUATION_RESULT" = "null" ]; then


### PR DESCRIPTION
## Description

Fixes the JSON parsing bug that prevented the hook from working with Claude Code 2.0.55+.

## Problem

The hook script was using the wrong jq selector to extract structured output from Claude's JSON response, causing all continuation evaluations to fail with a parse error.

## Solution

Changed line 110 from:
```bash
EVALUATION_RESULT=$(echo "$CLAUDE_RESPONSE" | jq '.[] | select(.type == "result") | .structured_output // empty' 2>/dev/null)
```

To:
```bash
EVALUATION_RESULT=$(echo "$CLAUDE_RESPONSE" | jq '.structured_output // empty' 2>/dev/null)
```

## Why This Works

When using `--output-format json`, Claude Code 2.0.55 returns a single JSON object with `structured_output` at the root level:

```json
{
  "type": "result",
  "structured_output": { ... },
  "session_id": "...",
  ...
}
```

The old selector tried to iterate over an array (`.[]`), which doesn't exist, causing jq to fail.

## Testing

- Manually verified that `jq '.structured_output'` successfully extracts the structured output
- Confirmed that Claude Code 2.0.55 supports the `--json-schema` flag
- The fix matches the documented JSON output format

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal evaluation result processing logic to improve system efficiency and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->