### PR TITLE
fix: Remove escaped quotes from hooks.json command path

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "double-shot-latte",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Automatically evaluates whether Claude should continue working instead of stopping prematurely using Claude-judged decision making",
   "author": {
     "name": "Jesse",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Double Shot Latte will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2026-01-02
+
+### Fixed
+- Fixed hook command execution failure on macOS/Linux caused by escaped quotes in `hooks.json`
+- Removed unnecessary `\"` around command path that conflicted with Claude Code's command parsing
+
 ## [1.1.5] - 2025-12-03
 
 ### Fixed

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" claude-judge-continuation.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd claude-judge-continuation.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Fixes hook execution failure on macOS/Linux where the plugin fails to start with:
```
Plugin hook ""/path/to/run-hook.cmd" claude-judge-continuation.sh" failed to start: The operation was aborted.
```

## Root Cause

The `hooks.json` command definition uses escaped quotes around the path:
```json
"command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" claude-judge-continuation.sh"
```

When Claude Code executes this, it wraps the entire command in quotes, resulting in malformed quoting:
```
""/path/to/run-hook.cmd" claude-judge-continuation.sh"
```

The double quotes at the start cause the shell to misinterpret the command.

## Fix

Remove the unnecessary escaped quotes since:
1. The path variable doesn't require quoting (contains no spaces in typical installations)
2. The `run-hook.cmd` polyglot wrapper handles path resolution internally via `$(dirname "$0")`

**Before:**
```json
"command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" claude-judge-continuation.sh"
```

**After:**
```json
"command": "${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd claude-judge-continuation.sh"
```

## Testing

- [x] Tested on macOS 15.2 (Darwin 25.2.0)
- [x] Verified hook executes successfully on Stop events
- [x] Confirmed `run-hook.cmd` polyglot wrapper still works correctly

## Environment

- **OS:** macOS 15.2 (Darwin 25.2.0)
- **Claude Code:** Latest version  
- **Plugin Version:** 1.1.5 → 1.1.6

## Related

This continues the cross-platform compatibility work from v1.1.5 which fixed POSIX shell syntax.

## Changes

- `hooks/hooks.json` - Removed escaped quotes from command path
- `CHANGELOG.md` - Added 1.1.6 entry documenting the fix
- `.claude-plugin/plugin.json` - Bumped version to 1.1.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hook command execution failures on macOS/Linux systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->