### PR TITLE
fix: add bash prefix for Unix compatibility

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" claude-judge-continuation.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" claude-judge-continuation.sh"
           }
         ]
       }


### PR DESCRIPTION
## Motivation and Context                                                     
  On macOS and Linux, `.cmd` files are not recognized as executable scripts     
  because there's no shebang line. This causes the Stop hook to fail, which     
  blocks Claude Code from completing (reported in #6 and                        
  anthropics/claude-code#17805).                                                
                                                                                
  ## How Has This Been Tested?                                                  
  Tested on macOS - Stop hook now executes successfully without hanging.        
                                                                                
  ## Breaking Changes                                                           
  None. Windows users already require Git Bash (which the plugin depends on), so
   `bash` will be available in PATH.                                            
                                                                                
  ## Types of changes                                                           
  - [x] Bug fix (non-breaking change which fixes an issue)                      
  - [ ] New feature (non-breaking change which adds functionality)              
  - [ ] Breaking change (fix or feature that would cause existing functionality 
  to change)                                                                    
  - [ ] Documentation update                                                    
                                                                                
  ## Checklist                                                                  
  - [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)    
  - [x] My code follows the repository's style guidelines                       
  - [x] New and existing tests pass locally                                     
  - [x] I have added appropriate error handling                                 
  - [ ] I have added or updated documentation as needed                         
                                                                                
  ## Additional context                                                         
  The `run-hook.cmd` is a polyglot script that works on both Windows and Unix.  
  However, Unix systems need an explicit `bash` invocation since they don't     
  recognize `.cmd` extensions. This fix adds the `bash` prefix while preserving 
  the polyglot wrapper's cross-platform logic. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed script execution behavior to ensure proper handling through bash interpreter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->