### PR TITLE
fix: POSIX sh compatibility for run-hook.cmd on Debian/Ubuntu

### DIFF
--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -39,7 +39,8 @@ exit /b 0
 CMDBLOCK
 
 # Unix: run the named script via explicit bash (no execute-bit required)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# Use $0 instead of BASH_SOURCE for POSIX sh (dash) compatibility
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT_NAME="$1"
 shift
 exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"


### PR DESCRIPTION
## Summary
- Replace `${BASH_SOURCE[0]:-$0}` with `$0` on line 42 of `hooks/run-hook.cmd`
- Fixes `Bad substitution` error when `/bin/sh` is `dash` (Debian/Ubuntu default)

## Problem
Claude Code executes hook commands via `/bin/sh`. On Debian/Ubuntu, `/bin/sh` is `dash`, which doesn't support `BASH_SOURCE` or bash array indexing syntax. This causes:

```
run-hook.cmd: 42: Bad substitution
bash: /home/user/projects/myproject/claude-judge-continuation: No such file or directory
```

## Fix
`$0` is POSIX-compatible and equivalent to `${BASH_SOURCE[0]:-$0}` when the script is executed directly (not sourced). Since Claude Code runs hook commands as subprocesses, `$0` is always the script path.

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved hook script compatibility for broader system support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->